### PR TITLE
Fix NPE when player steps on pressure plate

### DIFF
--- a/src/me/EtienneDx/RealEstate/REListener.java
+++ b/src/me/EtienneDx/RealEstate/REListener.java
@@ -357,7 +357,7 @@ public class REListener implements Listener
 	@EventHandler
 	public void onPlayerInteract(PlayerInteractEvent event)
 	{
-		if(event.getHand().equals(EquipmentSlot.HAND) && event.getAction().equals(Action.RIGHT_CLICK_BLOCK) && 
+		if(event.getAction().equals(Action.RIGHT_CLICK_BLOCK) && event.getHand().equals(EquipmentSlot.HAND) &&
 				event.getClickedBlock().getState() instanceof Sign)
 		{
 			Sign sign = (Sign)event.getClickedBlock().getState();


### PR DESCRIPTION
Resolves #4 

If `event.getAction()` is `Action.PHYSICAL`, `event.getHand()` returns null. This causes a NullPointerException during the check for the hand.

This was throwing when players stepped on pressure plates, etc.

Ensuring the action is `Action.RIGHT_CLICK_BLOCK` before attempting to get the hand resolves the issue.