### PR TITLE
Added currency symbol as a config option

### DIFF
--- a/src/me/EtienneDx/RealEstate/Config.java
+++ b/src/me/EtienneDx/RealEstate/Config.java
@@ -40,6 +40,9 @@ public class Config
     
     public boolean cfgTransferClaimBlocks;
 
+    public boolean cfgUseCurrencySymbol;
+    public String cfgCurrencySymbol;
+    
     public boolean cfgMessageOwner;
     public boolean cfgMessageBuyer;
     public boolean cfgBroadcastSell;
@@ -101,6 +104,9 @@ public class Config
 
     	this.cfgTransferClaimBlocks = config.getBoolean("RealEstate.Rules.TransferClaimBlocks", true);
 
+        this.cfgUseCurrencySymbol = config.getBoolean("RealEstate.Rules.UseCurrencySymbol", false);
+        this.cfgCurrencySymbol = config.getString("RealEstate.Rules.CurrencySymbol", "$");
+
         this.cfgMessageOwner = config.getBoolean("RealEstate.Messaging.MessageOwner", true);
         this.cfgMessageBuyer = config.getBoolean("RealEstate.Messaging.MessageBuyer", true);
         this.cfgMailOffline = config.getBoolean("RealEstate.Messaging.MailOffline", true);
@@ -146,6 +152,9 @@ public class Config
     	outConfig.set("RealEstate.Rules.DestroySigns.Lease", this.cfgDestroyLeaseSigns);
 
     	outConfig.set("RealEstate.Rules.TransferClaimBlocks", this.cfgTransferClaimBlocks);
+
+    	outConfig.set("RealEstate.Rules.UseCurrencySymbol", this.cfgUseCurrencySymbol);
+    	outConfig.set("RealEstate.Rules.CurrencySymbol", this.cfgCurrencySymbol);
 
     	outConfig.set("RealEstate.Messaging.MessageOwner", this.cfgMessageOwner);
     	outConfig.set("RealEstate.Messaging.MessageBuyer", this.cfgMessageBuyer);

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimLease.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimLease.java
@@ -71,7 +71,15 @@ public class ClaimLease extends BoughtTransaction
 				s.setLine(0, RealEstate.instance.config.cfgSignsHeader);
 				s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
 				//s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
-				s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
+				//s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
+				if(RealEstate.instance.config.cfgUseCurrencySymbol)
+				{
+					s.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+				}
+				else
+				{
+					s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
+				}
 				s.setLine(3, Utils.getTime(frequency, null, false));
 				s.update(true);
 			}

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimRent.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimRent.java
@@ -77,7 +77,14 @@ public class ClaimRent extends BoughtTransaction
 				s.setLine(0, RealEstate.instance.config.cfgSignsHeader);
 				s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
 				//s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
-				s.setLine(2, price + " " + RealEstate.econ.currencyNamePlural());
+				if(RealEstate.instance.config.cfgUseCurrencySymbol)
+				{
+					s.setLine(2, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+				}
+				else
+				{
+					s.setLine(2, price + " " + RealEstate.econ.currencyNamePlural());
+				}
 				s.setLine(3, (maxPeriod > 1 ? maxPeriod + "x " : "") + Utils.getTime(duration, null, false));
 				s.update(true);
 			}

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimSell.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimSell.java
@@ -31,7 +31,14 @@ public class ClaimSell extends ClaimTransaction
 			s.setLine(0, RealEstate.instance.config.cfgSignsHeader);
 			s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
 			s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
-			s.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
+			if(RealEstate.instance.config.cfgUseCurrencySymbol)
+			{
+				s.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+			}
+			else
+			{
+				s.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
+			}
 			s.update(true);
 		}
 		else


### PR DESCRIPTION
New feature in answer to #3 

Two new fields in the config : wether to use the symbol or the full name for the currency, and if symbol, what symbol should be used? (Symbols aren't synchronized over APIs for now)