### PR TITLE
Add api-version to plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,6 +3,7 @@ main: me.EtienneDx.RealEstate.RealEstate
 version: ${project.version}
 authors: [EtienneDx]
 depend: [GriefPrevention, Vault]
+api-version: "1.15"
 
 commands:
   re:


### PR DESCRIPTION
The plugin is being loaded as a "legacy plugin" because the api-version is not set. This should make Spigot stop complaining about how it doesn't have an api-version and allow it to load as a normal plugin.

Also, apparently the GitHub editor added a newline to the end of the file because there wasn't one.