### PR TITLE
Fixes so it works correctly on Spigot/Paper 1.20.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .classpath
 .project
 .idea

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<source>16</source>
-					<target>16</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>16</source>
+					<target>16</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>Me.EtienneDx</groupId>
 	<artifactId>real-estate</artifactId>
-	<version>1.5.0-pre1-MCPD1</version>
+	<version>1.5.0-pre2</version>
+
 	<name>RealEstate</name>
 	<description>A spigot plugin for selling, renting and leasing GriefPrevention claims</description>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>Me.EtienneDx</groupId>
 	<artifactId>real-estate</artifactId>
-	<version>1.5.0-pre1</version>
+	<version>1.5.0-pre1-MCPD1</version>
 	<name>RealEstate</name>
 	<description>A spigot plugin for selling, renting and leasing GriefPrevention claims</description>
 	<build>
@@ -36,7 +36,7 @@
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
 					<createDependencyReducedPom>false</createDependencyReducedPom>
 					<filters>
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18.1-R0.1-SNAPSHOT</version>
+			<version>1.20.1-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/me/EtienneDx/RealEstate/ClaimAPI/GriefPrevention/GriefPreventionAPI.java
+++ b/src/me/EtienneDx/RealEstate/ClaimAPI/GriefPrevention/GriefPreventionAPI.java
@@ -8,13 +8,19 @@ import me.EtienneDx.RealEstate.ClaimAPI.IClaim;
 import me.EtienneDx.RealEstate.ClaimAPI.IClaimAPI;
 import me.EtienneDx.RealEstate.ClaimAPI.IPlayerData;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.Claim;
 
 public class GriefPreventionAPI implements IClaimAPI
 {
-
     @Override
     public IClaim getClaimAt(Location location) {
-        return new GPClaim(GriefPrevention.instance.dataStore.getClaimAt(location, false, null));
+        Claim gpclaim = GriefPrevention.instance.dataStore.getClaimAt(location, false, null);
+
+        if (gpclaim == null) {
+            return null;
+        }
+
+        return new GPClaim(gpclaim);
     }
 
     @Override

--- a/src/me/EtienneDx/RealEstate/REListener.java
+++ b/src/me/EtienneDx/RealEstate/REListener.java
@@ -3,11 +3,8 @@ package me.EtienneDx.RealEstate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
-import org.bukkit.block.sign.Side;
-import org.bukkit.block.sign.SignSide;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -470,32 +467,15 @@ public class REListener implements Listener
 		return Double.parseDouble(event.getLine(line));
 	}
 
-	private boolean isRealEstateSign(Sign sign) {
-		String header = ChatColor.stripColor(Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-
-		SignSide front = sign.getSide(Side.FRONT);
-		SignSide back = sign.getSide(Side.BACK);
-
-		if(ChatColor.stripColor(front.getLine(0)).equalsIgnoreCase(header)) {
-				return true;
-		}
-
-		if(ChatColor.stripColor(back.getLine(0)).equalsIgnoreCase(header)) {
-				return true;
-		}
-
-		return false;
-	}
-
 	@EventHandler
 	public void onPlayerInteract(PlayerInteractEvent event)
 	{
 		if(event.getAction().equals(Action.RIGHT_CLICK_BLOCK) && event.getHand().equals(EquipmentSlot.HAND) &&
 				event.getClickedBlock().getState() instanceof Sign)
 		{
-			Sign sign = (Sign)event.getClickedBlock().getState();
+			RealEstateSign s = new RealEstateSign((Sign) event.getClickedBlock().getState());
 			// it is a real estate sign
-			if(isRealEstateSign(sign))
+			if(s.isRealEstateSign())
 			{
 				Player player = event.getPlayer();
 				IClaim claim = RealEstate.claimAPI.getClaimAt(event.getClickedBlock().getLocation());

--- a/src/me/EtienneDx/RealEstate/REListener.java
+++ b/src/me/EtienneDx/RealEstate/REListener.java
@@ -6,6 +6,8 @@ import java.util.regex.Pattern;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -468,6 +470,23 @@ public class REListener implements Listener
 		return Double.parseDouble(event.getLine(line));
 	}
 
+	private boolean isRealEstateSign(Sign sign) {
+		String header = ChatColor.stripColor(Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+
+		SignSide front = sign.getSide(Side.FRONT);
+		SignSide back = sign.getSide(Side.BACK);
+
+		if(ChatColor.stripColor(front.getLine(0)).equalsIgnoreCase(header)) {
+				return true;
+		}
+
+		if(ChatColor.stripColor(back.getLine(0)).equalsIgnoreCase(header)) {
+				return true;
+		}
+
+		return false;
+	}
+
 	@EventHandler
 	public void onPlayerInteract(PlayerInteractEvent event)
 	{
@@ -476,8 +495,7 @@ public class REListener implements Listener
 		{
 			Sign sign = (Sign)event.getClickedBlock().getState();
 			// it is a real estate sign
-			if(ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(ChatColor.stripColor(
-				Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false))))
+			if(isRealEstateSign(sign))
 			{
 				Player player = event.getPlayer();
 				IClaim claim = RealEstate.claimAPI.getClaimAt(event.getClickedBlock().getLocation());

--- a/src/me/EtienneDx/RealEstate/RealEstateSign.java
+++ b/src/me/EtienneDx/RealEstate/RealEstateSign.java
@@ -1,0 +1,46 @@
+package me.EtienneDx.RealEstate;
+
+import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
+import org.bukkit.ChatColor;
+
+public class RealEstateSign 
+{
+	private Sign sign;
+	private SignSide front;
+	private SignSide back;
+
+	public RealEstateSign(Sign sign) {
+		this.sign = sign;
+		this.front = sign.getSide(Side.FRONT);
+		this.back = sign.getSide(Side.BACK);
+	}
+
+	public void setLine(int line, String value) {
+		front.setLine(line, value);
+		back.setLine(line, value);
+	}
+
+	public void update(boolean force) {
+		sign.update(force);
+	}
+
+	public boolean isRealEstateSign() {
+		String header = ChatColor.stripColor(Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+
+		SignSide front = sign.getSide(Side.FRONT);
+		SignSide back = sign.getSide(Side.BACK);
+
+		if(ChatColor.stripColor(front.getLine(0)).equalsIgnoreCase(header)) {
+				return true;
+		}
+
+		if(ChatColor.stripColor(back.getLine(0)).equalsIgnoreCase(header)) {
+				return true;
+		}
+
+		return false;
+	}
+
+}

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimAuction.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimAuction.java
@@ -127,6 +127,7 @@ public class ClaimAuction extends ClaimTransaction {
                 s.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
                 s.setLine(2, "");
                 s.setLine(3, "");
+                s.update(true);
             }
             return true;
         }

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimAuction.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimAuction.java
@@ -13,6 +13,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -97,7 +99,7 @@ public class ClaimAuction extends ClaimTransaction {
                             Messages.sendMessage(buyerPlayer.getPlayer(), RealEstate.instance.messages.msgInfoClaimInfoAuctionCancelled);
                         }
                     }
-                    if(owner != null && ownerPlayer.isOnline())
+                    if(owner != null && ownerPlayer != null && ownerPlayer.isOnline())
                     {
                         Messages.sendMessage(ownerPlayer.getPlayer(), RealEstate.instance.messages.msgErrorAuctionCouldntReceiveOwner);
                     }
@@ -110,10 +112,16 @@ public class ClaimAuction extends ClaimTransaction {
                     if(getHolder().getState() instanceof Sign)
                     {
                         Sign sign = (Sign) getHolder().getState();
-                        sign.setLine(0, "");
-                        sign.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionWon, false));
-                        sign.setLine(2, buyerPlayer.getName());
-                        sign.setLine(3, "");
+                        SignSide front = sign.getSide(Side.FRONT);
+                        SignSide back = sign.getSide(Side.BACK);
+                        front.setLine(0, "");
+                        front.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionWon, false));
+                        front.setLine(2, buyerPlayer.getName());
+                        front.setLine(3, "");
+                        back.setLine(0, "");
+                        back.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionWon, false));
+                        back.setLine(2, buyerPlayer.getName());
+                        back.setLine(3, "");
                         sign.update();
                     }
                     return true;
@@ -122,10 +130,16 @@ public class ClaimAuction extends ClaimTransaction {
             if(getHolder().getState() instanceof Sign)
             {
                 Sign sign = (Sign) getHolder().getState();
-                sign.setLine(0, "");
-                sign.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
-                sign.setLine(2, "");
-                sign.setLine(3, "");
+                SignSide front = sign.getSide(Side.FRONT);
+                SignSide back = sign.getSide(Side.BACK);
+                front.setLine(0, "");
+                front.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
+                front.setLine(2, "");
+                front.setLine(3, "");
+                back.setLine(0, "");
+                back.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
+                back.setLine(2, "");
+                back.setLine(3, "");
                 sign.update();
             }
             return true;
@@ -136,18 +150,25 @@ public class ClaimAuction extends ClaimTransaction {
             if(sign.getBlock().getState() instanceof Sign)
             {
                 Sign s = (Sign) sign.getBlock().getState();
-                s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-                s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceAuction);
+                SignSide front = s.getSide(Side.FRONT);
+                SignSide back = s.getSide(Side.BACK);
+                front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+                back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+                front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceAuction);
+                back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceAuction);
                 String remaining = Utils.getTime(days, hours, false);
-                s.setLine(2, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionRemainingTime, false, remaining));
+                front.setLine(2, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionRemainingTime, false, remaining));
+                back.setLine(2, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionRemainingTime, false, remaining));
                 if(buyer != null)
                 {
                     String name = Bukkit.getOfflinePlayer(buyer).getName();
-                    s.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionHighestBidder, false, name, RealEstate.econ.format(price)));
+                    front.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionHighestBidder, false, name, RealEstate.econ.format(price)));
+                    back.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionHighestBidder, false, name, RealEstate.econ.format(price)));
                 }
                 else
                 {
-                    s.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionNoBider, false));
+                    front.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionNoBider, false));
+                    back.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionNoBider, false));
                 }
                 s.update(true);
             }

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimAuction.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimAuction.java
@@ -13,13 +13,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
-import org.bukkit.block.sign.Side;
-import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import me.EtienneDx.RealEstate.Messages;
 import me.EtienneDx.RealEstate.RealEstate;
+import me.EtienneDx.RealEstate.RealEstateSign;
 import me.EtienneDx.RealEstate.Utils;
 import me.EtienneDx.RealEstate.ClaimAPI.IClaim;
 import net.md_5.bungee.api.ChatColor;
@@ -111,36 +110,23 @@ public class ClaimAuction extends ClaimTransaction {
                     Utils.transferClaim(claim, buyer, owner);
                     if(getHolder().getState() instanceof Sign)
                     {
-                        Sign sign = (Sign) getHolder().getState();
-                        SignSide front = sign.getSide(Side.FRONT);
-                        SignSide back = sign.getSide(Side.BACK);
-                        front.setLine(0, "");
-                        front.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionWon, false));
-                        front.setLine(2, buyerPlayer.getName());
-                        front.setLine(3, "");
-                        back.setLine(0, "");
-                        back.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionWon, false));
-                        back.setLine(2, buyerPlayer.getName());
-                        back.setLine(3, "");
-                        sign.update();
+                        RealEstateSign s = new RealEstateSign((Sign) getHolder().getState());
+                        s.setLine(0, "");
+                        s.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionWon, false));
+                        s.setLine(2, buyerPlayer.getName());
+                        s.setLine(3, "");
+                        s.update(true);
                     }
                     return true;
                 }
             }
             if(getHolder().getState() instanceof Sign)
             {
-                Sign sign = (Sign) getHolder().getState();
-                SignSide front = sign.getSide(Side.FRONT);
-                SignSide back = sign.getSide(Side.BACK);
-                front.setLine(0, "");
-                front.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
-                front.setLine(2, "");
-                front.setLine(3, "");
-                back.setLine(0, "");
-                back.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
-                back.setLine(2, "");
-                back.setLine(3, "");
-                sign.update();
+                RealEstateSign s = new RealEstateSign((Sign) getHolder().getState());
+                s.setLine(0, "");
+                s.setLine(1, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionEnded, false));
+                s.setLine(2, "");
+                s.setLine(3, "");
             }
             return true;
         }
@@ -149,26 +135,19 @@ public class ClaimAuction extends ClaimTransaction {
             // update sign
             if(sign.getBlock().getState() instanceof Sign)
             {
-                Sign s = (Sign) sign.getBlock().getState();
-                SignSide front = s.getSide(Side.FRONT);
-                SignSide back = s.getSide(Side.BACK);
-                front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-                back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-                front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceAuction);
-                back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceAuction);
+                RealEstateSign s = new RealEstateSign((Sign) sign.getBlock().getState());
+                s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+                s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceAuction);
                 String remaining = Utils.getTime(days, hours, false);
-                front.setLine(2, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionRemainingTime, false, remaining));
-                back.setLine(2, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionRemainingTime, false, remaining));
+                s.setLine(2, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionRemainingTime, false, remaining));
                 if(buyer != null)
                 {
                     String name = Bukkit.getOfflinePlayer(buyer).getName();
-                    front.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionHighestBidder, false, name, RealEstate.econ.format(price)));
-                    back.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionHighestBidder, false, name, RealEstate.econ.format(price)));
+                    s.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionHighestBidder, false, name, RealEstate.econ.format(price)));
                 }
                 else
                 {
-                    front.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionNoBider, false));
-                    back.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionNoBider, false));
+                    s.setLine(3, Messages.getMessage(RealEstate.instance.messages.msgSignAuctionNoBider, false));
                 }
                 s.update(true);
             }

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimLease.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimLease.java
@@ -11,8 +11,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
-import org.bukkit.block.sign.Side;
-import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -21,6 +19,7 @@ import com.earth2me.essentials.User;
 import me.EtienneDx.RealEstate.Messages;
 import me.EtienneDx.RealEstate.RealEstate;
 import me.EtienneDx.RealEstate.Utils;
+import me.EtienneDx.RealEstate.RealEstateSign;
 import me.EtienneDx.RealEstate.ClaimAPI.ClaimPermission;
 import me.EtienneDx.RealEstate.ClaimAPI.IClaim;
 import net.md_5.bungee.api.ChatColor;
@@ -66,43 +65,34 @@ public class ClaimLease extends BoughtTransaction
 		{
 			if(sign.getBlock().getState() instanceof Sign)
 			{
-				Sign s = (Sign)sign.getBlock().getState();
-                SignSide front = s.getSide(Side.FRONT);
-                SignSide back = s.getSide(Side.BACK);
-				front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-				back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-				front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
-				back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
+				RealEstateSign s = new RealEstateSign((Sign) sign.getBlock().getState());
+				s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+				s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
 				//s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
 				//s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
 				if(RealEstate.instance.config.cfgUseCurrencySymbol)
 				{
 					if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 					{
-						front.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
-						back.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
+						s.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
 					}
 					else
 					{
-						front.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
-						back.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+						s.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
 					}
 				}
 				else
 				{
 					if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 					{
-						front.setLine(2, paymentsLeft + "x " + (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
-						back.setLine(2, paymentsLeft + "x " + (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
+						s.setLine(2, paymentsLeft + "x " + (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
 					}
 					else
 					{
-						front.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
-						back.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
+						s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
 					}
 				}
-				front.setLine(3, Utils.getTime(frequency, null, false));
-				back.setLine(3, Utils.getTime(frequency, null, false));
+				s.setLine(3, Utils.getTime(frequency, null, false));
 				s.update(true);
 			}
 			else

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimLease.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimLease.java
@@ -11,6 +11,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -65,33 +67,42 @@ public class ClaimLease extends BoughtTransaction
 			if(sign.getBlock().getState() instanceof Sign)
 			{
 				Sign s = (Sign)sign.getBlock().getState();
-				s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-				s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
+                SignSide front = s.getSide(Side.FRONT);
+                SignSide back = s.getSide(Side.BACK);
+				front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+				back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+				front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
+				back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceLease);
 				//s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
 				//s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
 				if(RealEstate.instance.config.cfgUseCurrencySymbol)
 				{
 					if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 					{
-						s.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
+						front.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
+						back.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
 					}
 					else
 					{
-						s.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+						front.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+						back.setLine(2, paymentsLeft + "x " + RealEstate.instance.config.cfgCurrencySymbol + " " + price);
 					}
 				}
 				else
 				{
 					if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 					{
-						s.setLine(2, paymentsLeft + "x " + (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
+						front.setLine(2, paymentsLeft + "x " + (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
+						back.setLine(2, paymentsLeft + "x " + (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
 					}
 					else
 					{
-						s.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
+						front.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
+						back.setLine(2, paymentsLeft + "x " + price + " " + RealEstate.econ.currencyNamePlural());
 					}
 				}
-				s.setLine(3, Utils.getTime(frequency, null, false));
+				front.setLine(3, Utils.getTime(frequency, null, false));
+				back.setLine(3, Utils.getTime(frequency, null, false));
 				s.update(true);
 			}
 			else
@@ -155,7 +166,7 @@ public class ClaimLease extends BoughtTransaction
 				
 				if(owner != null)
 				{
-					if(seller.isOnline() && RealEstate.instance.config.cfgMessageOwner)
+					if(seller != null && seller.isOnline() && RealEstate.instance.config.cfgMessageOwner)
 					{
 						Messages.sendMessage(seller.getPlayer(), RealEstate.instance.messages.msgInfoClaimInfoLeasePaymentOwner, 
 								buyerPlayer.getName(),
@@ -194,7 +205,7 @@ public class ClaimLease extends BoughtTransaction
 							RealEstate.econ.format(price)));
 	        	}
 				
-				if(seller.isOnline() && RealEstate.instance.config.cfgMessageOwner)
+				if(seller != null && seller.isOnline() && RealEstate.instance.config.cfgMessageOwner)
 				{
 					Messages.sendMessage(seller.getPlayer(), RealEstate.instance.messages.msgInfoClaimInfoLeasePaymentOwnerFinal, 
 							buyerPlayer.getName(),
@@ -256,7 +267,7 @@ public class ClaimLease extends BoughtTransaction
 						location,
 						RealEstate.econ.format(price)));
 	    	}
-			if(seller.isOnline() && RealEstate.instance.config.cfgMessageOwner)
+			if(seller != null && seller.isOnline() && RealEstate.instance.config.cfgMessageOwner)
 			{
 				Messages.sendMessage(seller.getPlayer(), RealEstate.instance.messages.msgInfoClaimInfoLeasePaymentOwnerCancelled, 
 						buyerPlayer.getName(),

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimRent.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimRent.java
@@ -11,6 +11,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -73,8 +75,12 @@ public class ClaimRent extends BoughtTransaction
 			if(sign.getBlock().getState() instanceof Sign)
 			{
 				Sign s = (Sign) sign.getBlock().getState();
-				s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-				s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
+                SignSide front = s.getSide(Side.FRONT);
+                SignSide back = s.getSide(Side.BACK);
+				front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+				back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+				front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
+				back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
 				//s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
 				String price_line = "";
 				if(RealEstate.instance.config.cfgUseCurrencySymbol)
@@ -102,11 +108,15 @@ public class ClaimRent extends BoughtTransaction
 				}
 				String period = Utils.getTime(duration, null, false);
 				if(this.buildTrust) {
-					s.setLine(2, price_line);
-					s.setLine(3, period);
+					front.setLine(2, price_line);
+					back.setLine(2, price_line);
+					front.setLine(3, period);
+					back.setLine(3, period);
 				} else {
-					s.setLine(2, RealEstate.instance.config.cfgContainerRentLine);
-					s.setLine(3, price_line + " - " + period);
+					front.setLine(2, RealEstate.instance.config.cfgContainerRentLine);
+					back.setLine(2, RealEstate.instance.config.cfgContainerRentLine);
+					front.setLine(3, price_line + " - " + period);
+					back.setLine(3, price_line + " - " + period);
 				}
 				s.update(true);
 			}
@@ -132,14 +142,20 @@ public class ClaimRent extends BoughtTransaction
 			else if(sign.getBlock().getState() instanceof Sign)
 			{
 				Sign s = (Sign) sign.getBlock().getState();
-				s.setLine(0, ChatColor.GOLD + RealEstate.instance.config.cfgReplaceOngoingRent); //Changed the header to "[Rented]" so that it won't waste space on the next line and allow the name of the player to show underneath.
-				s.setLine(1, Utils.getSignString(Bukkit.getOfflinePlayer(buyer).getName()));//remove "Rented by"
-				s.setLine(2, "Time remaining : ");
+                SignSide front = s.getSide(Side.FRONT);
+                SignSide back = s.getSide(Side.BACK);
+				front.setLine(0, ChatColor.GOLD + RealEstate.instance.config.cfgReplaceOngoingRent); //Changed the header to "[Rented]" so that it won't waste space on the next line and allow the name of the player to show underneath.
+				back.setLine(0, ChatColor.GOLD + RealEstate.instance.config.cfgReplaceOngoingRent); //Changed the header to "[Rented]" so that it won't waste space on the next line and allow the name of the player to show underneath.
+				front.setLine(1, Utils.getSignString(Bukkit.getOfflinePlayer(buyer).getName()));//remove "Rented by"
+				back.setLine(1, Utils.getSignString(Bukkit.getOfflinePlayer(buyer).getName()));//remove "Rented by"
+				front.setLine(2, "Time remaining : ");
+				back.setLine(2, "Time remaining : ");
 				
 				int daysLeft = duration - days - 1;// we need to remove the current day
 				Duration timeRemaining = Duration.ofHours(24).minus(hours);
 				
-				s.setLine(3, Utils.getTime(daysLeft, timeRemaining, false));
+				front.setLine(3, Utils.getTime(daysLeft, timeRemaining, false));
+				back.setLine(3, Utils.getTime(daysLeft, timeRemaining, false));
 				s.update(true);
 			}
 		}

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimRent.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimRent.java
@@ -11,8 +11,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
-import org.bukkit.block.sign.Side;
-import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -21,6 +19,7 @@ import com.earth2me.essentials.User;
 import me.EtienneDx.RealEstate.Messages;
 import me.EtienneDx.RealEstate.RealEstate;
 import me.EtienneDx.RealEstate.Utils;
+import me.EtienneDx.RealEstate.RealEstateSign;
 import me.EtienneDx.RealEstate.ClaimAPI.ClaimPermission;
 import me.EtienneDx.RealEstate.ClaimAPI.IClaim;
 import net.md_5.bungee.api.ChatColor;
@@ -74,13 +73,9 @@ public class ClaimRent extends BoughtTransaction
 		{
 			if(sign.getBlock().getState() instanceof Sign)
 			{
-				Sign s = (Sign) sign.getBlock().getState();
-                SignSide front = s.getSide(Side.FRONT);
-                SignSide back = s.getSide(Side.BACK);
-				front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-				back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-				front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
-				back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
+				RealEstateSign s = new RealEstateSign((Sign) sign.getBlock().getState());
+				s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+				s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceRent);
 				//s.setLine(2, owner != null ? Bukkit.getOfflinePlayer(owner).getName() : "SERVER");
 				String price_line = "";
 				if(RealEstate.instance.config.cfgUseCurrencySymbol)
@@ -108,15 +103,11 @@ public class ClaimRent extends BoughtTransaction
 				}
 				String period = Utils.getTime(duration, null, false);
 				if(this.buildTrust) {
-					front.setLine(2, price_line);
-					back.setLine(2, price_line);
-					front.setLine(3, period);
-					back.setLine(3, period);
+					s.setLine(2, price_line);
+					s.setLine(3, period);
 				} else {
-					front.setLine(2, RealEstate.instance.config.cfgContainerRentLine);
-					back.setLine(2, RealEstate.instance.config.cfgContainerRentLine);
-					front.setLine(3, price_line + " - " + period);
-					back.setLine(3, price_line + " - " + period);
+					s.setLine(2, RealEstate.instance.config.cfgContainerRentLine);
+					s.setLine(3, price_line + " - " + period);
 				}
 				s.update(true);
 			}
@@ -141,21 +132,15 @@ public class ClaimRent extends BoughtTransaction
 			}
 			else if(sign.getBlock().getState() instanceof Sign)
 			{
-				Sign s = (Sign) sign.getBlock().getState();
-                SignSide front = s.getSide(Side.FRONT);
-                SignSide back = s.getSide(Side.BACK);
-				front.setLine(0, ChatColor.GOLD + RealEstate.instance.config.cfgReplaceOngoingRent); //Changed the header to "[Rented]" so that it won't waste space on the next line and allow the name of the player to show underneath.
-				back.setLine(0, ChatColor.GOLD + RealEstate.instance.config.cfgReplaceOngoingRent); //Changed the header to "[Rented]" so that it won't waste space on the next line and allow the name of the player to show underneath.
-				front.setLine(1, Utils.getSignString(Bukkit.getOfflinePlayer(buyer).getName()));//remove "Rented by"
-				back.setLine(1, Utils.getSignString(Bukkit.getOfflinePlayer(buyer).getName()));//remove "Rented by"
-				front.setLine(2, "Time remaining : ");
-				back.setLine(2, "Time remaining : ");
+				RealEstateSign s = new RealEstateSign((Sign) sign.getBlock().getState());
+				s.setLine(0, ChatColor.GOLD + RealEstate.instance.config.cfgReplaceOngoingRent); //Changed the header to "[Rented]" so that it won't waste space on the next line and allow the name of the player to show underneath.
+				s.setLine(1, Utils.getSignString(Bukkit.getOfflinePlayer(buyer).getName()));//remove "Rented by"
+				s.setLine(2, "Time remaining : ");
 				
 				int daysLeft = duration - days - 1;// we need to remove the current day
 				Duration timeRemaining = Duration.ofHours(24).minus(hours);
 				
-				front.setLine(3, Utils.getTime(daysLeft, timeRemaining, false));
-				back.setLine(3, Utils.getTime(daysLeft, timeRemaining, false));
+				s.setLine(3, Utils.getTime(daysLeft, timeRemaining, false));
 				s.update(true);
 			}
 		}

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimSell.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimSell.java
@@ -16,6 +16,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 
 public class ClaimSell extends ClaimTransaction
@@ -36,29 +38,38 @@ public class ClaimSell extends ClaimTransaction
 		if(sign.getBlock().getState() instanceof Sign)
 		{
 			Sign s = (Sign) sign.getBlock().getState();
-			s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-			s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
-			s.setLine(2, owner != null ? Utils.getSignString(Bukkit.getOfflinePlayer(owner).getName()) : "SERVER");
+			SignSide front = s.getSide(Side.FRONT);
+			SignSide back = s.getSide(Side.BACK);
+			front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+			back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+			front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
+			back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
+			front.setLine(2, owner != null ? Utils.getSignString(Bukkit.getOfflinePlayer(owner).getName()) : "SERVER");
+			back.setLine(2, owner != null ? Utils.getSignString(Bukkit.getOfflinePlayer(owner).getName()) : "SERVER");
 			if(RealEstate.instance.config.cfgUseCurrencySymbol)
 			{
 				if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 				{
-					s.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
+					front.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
+					back.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
 				}
 				else
 				{
-					s.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+					front.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+					back.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
 				}
 			}
 			else
 			{
 				if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 				{
-					s.setLine(3, (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
+					front.setLine(3, (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
+					back.setLine(3, (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
 				}
 				else
 				{
-					s.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
+					front.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
+					back.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
 				}
 			}
 			s.update(true);

--- a/src/me/EtienneDx/RealEstate/Transactions/ClaimSell.java
+++ b/src/me/EtienneDx/RealEstate/Transactions/ClaimSell.java
@@ -7,6 +7,7 @@ import com.earth2me.essentials.User;
 import me.EtienneDx.RealEstate.Messages;
 import me.EtienneDx.RealEstate.RealEstate;
 import me.EtienneDx.RealEstate.Utils;
+import me.EtienneDx.RealEstate.RealEstateSign;
 import me.EtienneDx.RealEstate.ClaimAPI.IClaim;
 import net.md_5.bungee.api.ChatColor;
 
@@ -16,8 +17,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Sign;
-import org.bukkit.block.sign.Side;
-import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 
 public class ClaimSell extends ClaimTransaction
@@ -37,39 +36,30 @@ public class ClaimSell extends ClaimTransaction
 	{
 		if(sign.getBlock().getState() instanceof Sign)
 		{
-			Sign s = (Sign) sign.getBlock().getState();
-			SignSide front = s.getSide(Side.FRONT);
-			SignSide back = s.getSide(Side.BACK);
-			front.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-			back.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
-			front.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
-			back.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
-			front.setLine(2, owner != null ? Utils.getSignString(Bukkit.getOfflinePlayer(owner).getName()) : "SERVER");
-			back.setLine(2, owner != null ? Utils.getSignString(Bukkit.getOfflinePlayer(owner).getName()) : "SERVER");
+			RealEstateSign s = new RealEstateSign((Sign) sign.getBlock().getState());
+			s.setLine(0, Messages.getMessage(RealEstate.instance.config.cfgSignsHeader, false));
+			s.setLine(1, ChatColor.DARK_GREEN + RealEstate.instance.config.cfgReplaceSell);
+			s.setLine(2, owner != null ? Utils.getSignString(Bukkit.getOfflinePlayer(owner).getName()) : "SERVER");
 			if(RealEstate.instance.config.cfgUseCurrencySymbol)
 			{
 				if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 				{
-					front.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
-					back.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
+					s.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + (int)Math.round(price));
 				}
 				else
 				{
-					front.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
-					back.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
+					s.setLine(3, RealEstate.instance.config.cfgCurrencySymbol + " " + price);
 				}
 			}
 			else
 			{
 				if(RealEstate.instance.config.cfgUseDecimalCurrency == false)
 				{
-					front.setLine(3, (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
-					back.setLine(3, (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
+					s.setLine(3, (int)Math.round(price) + " " + RealEstate.econ.currencyNamePlural());
 				}
 				else
 				{
-					front.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
-					back.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
+					s.setLine(3, price + " " + RealEstate.econ.currencyNamePlural());
 				}
 			}
 			s.update(true);

--- a/src/me/EtienneDx/RealEstate/Utils.java
+++ b/src/me/EtienneDx/RealEstate/Utils.java
@@ -55,7 +55,7 @@ public class Utils
         		{
 					Messages.sendMessage(giveTo.getPlayer(), RealEstate.instance.messages.msgErrorNoDepositOther, giveTo.getName());
         		}
-        		if(giveTo != null && giveTo.isOnline() && msgReceiver)
+        		if(takeFrom != null && giveTo != null && giveTo.isOnline() && msgReceiver)
         		{
 					Messages.sendMessage(takeFrom.getPlayer(), RealEstate.instance.messages.msgErrorNoDepositSelf, takeFrom.getName());
         		}


### PR DESCRIPTION
* Fixed an issue with exceptions generated when signs are not inside GriefPrevention claims
* Fixed an issue where the text on [sell] signs wasn't showing up
  * Updated to Spigot API 1.20.1 (to fix sell signs)
  * Put sign text on front and back of signs
* Fixed null warnings
* Fixed build (which required updating the maven shade plugin)
